### PR TITLE
Fixed Warning: count(): Parameter must be an array or an object that …

### DIFF
--- a/library/Zend/Db/Table/Abstract.php
+++ b/library/Zend/Db/Table/Abstract.php
@@ -1304,13 +1304,13 @@ abstract class Zend_Db_Table_Abstract
         $whereList = array();
         $numberTerms = 0;
         foreach ($args as $keyPosition => $keyValues) {
-            $keyValuesCount = count($keyValues);
             // Coerce the values to an array.
             // Don't simply typecast to array, because the values
             // might be Zend_Db_Expr objects.
             if (!is_array($keyValues)) {
                 $keyValues = array($keyValues);
             }
+            $keyValuesCount = count($keyValues);
             if ($numberTerms == 0) {
                 $numberTerms = $keyValuesCount;
             } else if ($keyValuesCount != $numberTerms) {


### PR DESCRIPTION
…implements Countable when $keyValuesCount is not an array

count($keyValuesCount) happens before the $keyValuesCount are always an array, setting the count after the code that makes it an array means the warning is dealt with and the code is now correct as $keyValuesCount will always contain a count value.